### PR TITLE
object architecture

### DIFF
--- a/lib/cubscout.rb
+++ b/lib/cubscout.rb
@@ -5,7 +5,9 @@ require "cubscout/resource"
 require "cubscout/request"
 require "cubscout/response"
 
+require "cubscout/scopes"
 require "cubscout/list"
+require "cubscout/object"
 require "cubscout/conversation"
 require "cubscout/user"
 

--- a/lib/cubscout/conversation.rb
+++ b/lib/cubscout/conversation.rb
@@ -4,13 +4,21 @@ module Cubscout
 
     class << self
       def threads(id)
-        Cubscout.connection.get("#{read_path}/#{id}/threads").body.dig("_embedded", "threads")
+        Cubscout.connection.get("#{read_path}/#{id}/threads").body.dig("_embedded", "threads").map { |item| Object.new(item) }
       end
 
       def create_note(id, attributes)
         raise "Missing attribute `text` while creating new note" unless attributes.has_key?(:text)
         Cubscout.connection.post("#{read_path}/#{id}/notes", attributes.to_json)
       end
+    end
+
+    def threads
+      Conversation.threads(self.id)
+    end
+
+    def create_note(attributes)
+      Conversation.create_note(self.id, attributes)
     end
   end
 end

--- a/lib/cubscout/conversation.rb
+++ b/lib/cubscout/conversation.rb
@@ -1,12 +1,8 @@
 module Cubscout
-  class Conversation < List
+  class Conversation < Object
     path "conversations"
 
     class << self
-      def find(id)
-        Cubscout.connection.get("#{read_path}/#{id}")
-      end
-
       def threads(id)
         Cubscout.connection.get("#{read_path}/#{id}/threads").body.dig("_embedded", "threads")
       end

--- a/lib/cubscout/list.rb
+++ b/lib/cubscout/list.rb
@@ -2,36 +2,9 @@ module Cubscout
   class List
     include Enumerable
 
-    class << self
-      def path(the_path)
-        @path = the_path
-      end
-
-      def read_path
-        @path
-      end
-
-      def all(options = {})
-        raise "No path given" unless @path
-
-        first_page = new(Cubscout.connection.get(@path, page: options[:page] || 1, **options).body)
-
-        if options[:page]
-          first_page.items
-        else
-          last_page = first_page.number_of_pages
-
-          other_pages = (2..last_page).to_a.map do |page|
-            new(Cubscout.connection.get(@path, page: page, **options).body)
-          end
-
-          (first_page.items + other_pages.map(&:items)).flatten
-        end
-      end
-    end
-
-    def initialize(raw_payload)
+    def initialize(raw_payload, collection_name)
       @raw_payload = raw_payload
+      @collection_name = collection_name
     end
 
     def page
@@ -51,7 +24,7 @@ module Cubscout
     end
 
     def items
-      raw_payload.dig("_embedded", self.class.read_path)
+      raw_payload.dig("_embedded", collection_name)
     end
 
     def each(&block)
@@ -60,6 +33,6 @@ module Cubscout
 
     private
 
-    attr_reader :raw_payload
+    attr_reader :raw_payload, :collection_name
   end
 end

--- a/lib/cubscout/list.rb
+++ b/lib/cubscout/list.rb
@@ -2,9 +2,10 @@ module Cubscout
   class List
     include Enumerable
 
-    def initialize(raw_payload, collection_name)
+    def initialize(raw_payload, collection_name, object_class)
       @raw_payload = raw_payload
       @collection_name = collection_name
+      @object_class = object_class
     end
 
     def page
@@ -24,7 +25,7 @@ module Cubscout
     end
 
     def items
-      raw_payload.dig("_embedded", collection_name)
+      raw_payload.dig("_embedded", collection_name).map { |item| object_class.new(item) }
     end
 
     def each(&block)
@@ -33,6 +34,6 @@ module Cubscout
 
     private
 
-    attr_reader :raw_payload, :collection_name
+    attr_reader :raw_payload, :collection_name, :object_class
   end
 end

--- a/lib/cubscout/object.rb
+++ b/lib/cubscout/object.rb
@@ -1,5 +1,25 @@
 module Cubscout
   class Object
     include Scopes
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def method_missing(method_name, *args, &block)
+      key = camelize(method_name)
+      return super unless @attributes.key?(key)
+
+      @attributes[key]
+    end
+
+    def underscore(string)
+      string.gsub(/[A-Z]/) { "_#{$&.downcase}" }
+    end
+
+    def camelize(sym)
+      parts = sym.to_s.split('_')
+      parts[0] + parts[1..-1].map(&:capitalize).join
+    end
   end
 end

--- a/lib/cubscout/object.rb
+++ b/lib/cubscout/object.rb
@@ -1,0 +1,5 @@
+module Cubscout
+  class Object
+    include Scopes
+  end
+end

--- a/lib/cubscout/request.rb
+++ b/lib/cubscout/request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Cubscout
-  class Request < Faraday:: Middleware
+  class Request < Faraday::Middleware
     def call(env)
       env.request_headers['Authorization'] = "Bearer #{Config.oauth_token}"
       env.request_headers['Content-Type'] = 'application/json'

--- a/lib/cubscout/scopes.rb
+++ b/lib/cubscout/scopes.rb
@@ -12,7 +12,7 @@ module Cubscout
       def all(options = {})
         raise "No path given" unless @path
 
-        first_page = List.new(Cubscout.connection.get(@path, page: options[:page] || 1, **options).body, @path)
+        first_page = List.new(Cubscout.connection.get(@path, page: options[:page] || 1, **options).body, @path, self)
 
         if options[:page]
           first_page.items
@@ -20,7 +20,7 @@ module Cubscout
           last_page = first_page.number_of_pages
 
           other_pages = (2..last_page).to_a.map do |page|
-            List.new(Cubscout.connection.get(@path, page: page, **options).body, @path)
+            List.new(Cubscout.connection.get(@path, page: page, **options).body, @path, self)
           end
 
           (first_page.items + other_pages.map(&:items)).flatten
@@ -28,7 +28,7 @@ module Cubscout
       end
 
       def find(id)
-        Cubscout.connection.get("#{@path}/#{id}").body
+        self.new(Cubscout.connection.get("#{@path}/#{id}").body)
       end
     end
 

--- a/lib/cubscout/scopes.rb
+++ b/lib/cubscout/scopes.rb
@@ -1,0 +1,39 @@
+module Cubscout
+  module Scopes
+    module ClassMethods
+      def path(the_path)
+        @path = the_path
+      end
+
+      def read_path
+        @path
+      end
+
+      def all(options = {})
+        raise "No path given" unless @path
+
+        first_page = List.new(Cubscout.connection.get(@path, page: options[:page] || 1, **options).body, @path)
+
+        if options[:page]
+          first_page.items
+        else
+          last_page = first_page.number_of_pages
+
+          other_pages = (2..last_page).to_a.map do |page|
+            List.new(Cubscout.connection.get(@path, page: page, **options).body, @path)
+          end
+
+          (first_page.items + other_pages.map(&:items)).flatten
+        end
+      end
+
+      def find(id)
+        Cubscout.connection.get("#{@path}/#{id}").body
+      end
+    end
+
+    def self.included(mod)
+      mod.extend ClassMethods
+    end
+  end
+end

--- a/lib/cubscout/user.rb
+++ b/lib/cubscout/user.rb
@@ -1,5 +1,5 @@
 module Cubscout
-  class User < List
+  class User < Object
     path "users"
   end
 end


### PR DESCRIPTION
# About

Instead of returning raw hashes, return objects (and array of objects for lists) whose attributes are accessible as methods

example:

```ruby
users = Cubscout::User.all
user = Cubscout::User.find(users.first.id)
puts user.first_name
# => "Tim"
```