### PR TITLE
Rate limit handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     jwt (2.1.0)
+    method_source (0.9.2)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -21,6 +23,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (2.0.6)
     rake (10.5.0)
     rspec (3.8.0)
@@ -43,6 +48,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   cubscout!
+  pry (~> 0.12)
   rake (~> 10.0)
   rspec (~> 3.0)
 

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 
 require "bundler/setup"
 require "cubscout"
+require "pry"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/cubscout.gemspec
+++ b/cubscout.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry", "~> 0.12"
 end

--- a/lib/cubscout.rb
+++ b/lib/cubscout.rb
@@ -19,4 +19,5 @@ module Cubscout
   class MalformedRequestError < StandardError; end
   class PermissionDeniedError < StandardError; end
   class ResourceNotFoundError < StandardError; end
+  class RateLimitExceeded < StandardError; end
 end

--- a/lib/cubscout/response.rb
+++ b/lib/cubscout/response.rb
@@ -5,24 +5,29 @@ require "json"
 module Cubscout
   class Response < Faraday::Response::Middleware
     def on_complete(env)
-      handle_response_status(env.status, env.body)
+      handle_response_status(env.status, env)
       parse_json_reponse(env)
     end
 
     private
 
-    def handle_response_status(status, body)
+    def handle_response_status(status, env)
       case status
       when 400
-        raise Cubscout::MalformedRequestError, body
+        raise Cubscout::MalformedRequestError, env.body
       when 401
-        raise Cubscout::AuthenticationError, body
+        raise Cubscout::AuthenticationError, env.body
       when 403
-        raise Cubscout::PermissionDeniedError, body
+        raise Cubscout::PermissionDeniedError, env.body
       when 404
-        raise Cubscout::ResourceNotFoundError, body
+        raise Cubscout::ResourceNotFoundError, env.body
+      when 429
+        limit = env.response_headers["x-ratelimit-limit-minute"]
+        remaining = env.response_headers["x-ratelimit-remaining-minute"]
+        retry_after = env.response_headers["x-ratelimit-retry-after"]
+        raise Cubscout::RateLimitExceeded, {retry_after_minutes: retry_after, limit: limit, remaining: remaining}
       when 500
-        raise Cubscout::InternalError, body
+        raise Cubscout::InternalError, env.body
       end
     end
 


### PR DESCRIPTION
Raises a custom error with info about the rate limit.

```
raise Cubscout::RateLimitExceeded, {retry_after_minutes: retry_after, limit: limit, remaining: remaining}
```