### PR TITLE
create note: return body instead of whole response

### DIFF
--- a/lib/cubscout/conversation.rb
+++ b/lib/cubscout/conversation.rb
@@ -9,7 +9,7 @@ module Cubscout
 
       def create_note(id, attributes)
         raise "Missing attribute `text` while creating new note" unless attributes.has_key?(:text)
-        Cubscout.connection.post("#{read_path}/#{id}/notes", attributes.to_json)
+        Cubscout.connection.post("#{read_path}/#{id}/notes", attributes.to_json).body
       end
     end
 


### PR DESCRIPTION
# About

When creating a note, the API response is `status 201` and the body is an empty string. We shouldn't return the whole response though.