### PR TITLE
Spec all existing endpoints + some polish

### DIFF
--- a/lib/cubscout/conversation.rb
+++ b/lib/cubscout/conversation.rb
@@ -7,9 +7,8 @@ module Cubscout
         Cubscout.connection.get("#{read_path}/#{id}/threads").body.dig("_embedded", "threads").map { |item| Object.new(item) }
       end
 
-      def create_note(id, attributes)
-        raise "Missing attribute `text` while creating new note" unless attributes.has_key?(:text)
-        Cubscout.connection.post("#{read_path}/#{id}/notes", attributes.to_json).body
+      def create_note(id, text:, **attributes)
+        Cubscout.connection.post("#{read_path}/#{id}/notes", attributes.merge(text: text).to_json).body
       end
     end
 

--- a/lib/cubscout/conversation.rb
+++ b/lib/cubscout/conversation.rb
@@ -1,14 +1,14 @@
 module Cubscout
   class Conversation < Object
-    path "conversations"
+    endpoint "conversations"
 
     class << self
       def threads(id)
-        Cubscout.connection.get("#{read_path}/#{id}/threads").body.dig("_embedded", "threads").map { |item| Object.new(item) }
+        Cubscout.connection.get("#{path}/#{id}/threads").body.dig("_embedded", "threads").map { |item| Object.new(item) }
       end
 
       def create_note(id, text:, **attributes)
-        Cubscout.connection.post("#{read_path}/#{id}/notes", attributes.merge(text: text).to_json).body
+        Cubscout.connection.post("#{path}/#{id}/notes", attributes.merge(text: text).to_json).body
       end
     end
 

--- a/lib/cubscout/object.rb
+++ b/lib/cubscout/object.rb
@@ -5,7 +5,8 @@ module Cubscout
     attr_reader :attributes
 
     def initialize(attributes)
-      @attributes = attributes
+      # Dirty deep_transform_keys to strings
+      @attributes = JSON.parse(attributes.to_json)
     end
 
     def method_missing(method_name, *args, &block)
@@ -13,10 +14,6 @@ module Cubscout
       return super unless @attributes.key?(key)
 
       @attributes[key]
-    end
-
-    def underscore(string)
-      string.gsub(/[A-Z]/) { "_#{$&.downcase}" }
     end
 
     def camelize(sym)

--- a/lib/cubscout/scopes.rb
+++ b/lib/cubscout/scopes.rb
@@ -1,18 +1,18 @@
 module Cubscout
   module Scopes
     module ClassMethods
-      def path(the_path)
-        @path = the_path
+      def endpoint(path)
+        @path = path
       end
 
-      def read_path
+      def path
         @path
       end
 
       def all(options = {})
-        raise "No path given" unless @path
+        raise "No path given" unless path
 
-        first_page = List.new(Cubscout.connection.get(@path, page: options[:page] || 1, **options).body, @path, self)
+        first_page = List.new(Cubscout.connection.get(path, page: options[:page] || 1, **options).body, path, self)
 
         if options[:page]
           first_page.items
@@ -20,7 +20,7 @@ module Cubscout
           last_page = first_page.number_of_pages
 
           other_pages = (2..last_page).to_a.map do |page|
-            List.new(Cubscout.connection.get(@path, page: page, **options).body, @path, self)
+            List.new(Cubscout.connection.get(path, page: page, **options).body, path, self)
           end
 
           (first_page.items + other_pages.map(&:items)).flatten
@@ -28,7 +28,7 @@ module Cubscout
       end
 
       def find(id)
-        self.new(Cubscout.connection.get("#{@path}/#{id}").body)
+        self.new(Cubscout.connection.get("#{path}/#{id}").body)
       end
     end
 

--- a/lib/cubscout/user.rb
+++ b/lib/cubscout/user.rb
@@ -1,5 +1,5 @@
 module Cubscout
   class User < Object
-    path "users"
+    endpoint "users"
   end
 end

--- a/spec/cubscout/conversation_spec.rb
+++ b/spec/cubscout/conversation_spec.rb
@@ -1,13 +1,113 @@
 RSpec.describe Cubscout::Conversation do
-  describe "#all" do
+  describe ".all" do
     it "gets all conversations" do
-      stub_request(:get, %r{https://api.helpscout.net/v2/conversations\?page\=*}).
+      stub_request(:get, %r{https://api.helpscout.net/v2/conversations\?page=*}).
         to_return(status: 200, body: File.read("#{__dir__}/../support/conversations.json"))
 
       convos = Cubscout::Conversation.all
 
       expect(convos.size).to eq 6
       expect(convos.first.class).to eq Cubscout::Conversation
+    end
+
+    it "gets one page of conversations" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/conversations\?page=1}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/conversations.json"))
+
+      convos = Cubscout::Conversation.all(page: 1)
+
+      expect(convos.size).to eq 2
+    end
+
+    it "gets a filtered list of conversations" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/conversations\?page=1&status=active&tag=red,blue}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/conversations.json"))
+
+      convos = Cubscout::Conversation.all(page: 1, status: "active", tag: "red,blue")
+
+      expect(convos.size).to eq 2
+    end
+  end
+
+  describe ".find" do
+    it "gets one conversation" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/conversations/\d+}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/conversation.json"))
+
+      convo = Cubscout::Conversation.find(123)
+
+      expect(convo.class).to eq Cubscout::Conversation
+    end
+
+    it "attributes are readable as both camel case and snake case" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/conversations/\d+}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/conversation.json"))
+
+      convo = Cubscout::Conversation.find(123)
+
+      expect(convo.mailboxId).to eq 121212
+      expect(convo.mailbox_id).to eq 121212
+    end
+  end
+
+  describe ".threads" do
+    it "gets the threads by conversation id" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/conversations/\d+/threads}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/threads.json"))
+
+      threads = Cubscout::Conversation.threads(123)
+
+      expect(threads.size).to eq 3
+      expect(threads.first.class).to eq Cubscout::Object
+    end
+  end
+
+  describe ".create_note" do
+    it "requires text" do
+      expect { Cubscout::Conversation.create_note(123) }.to raise_exception ArgumentError
+    end
+
+    it "creates a text note on a conversation" do
+      stub_request(:post, %r{https://api.helpscout.net/v2/conversations/\d+/notes}).
+        to_return(status: 201)
+
+      expect {
+        Cubscout::Conversation.create_note(123, text: "new note")
+      }.not_to raise_exception
+    end
+  end
+
+  describe "#threads" do
+    it "gets the threads of a conversation" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/conversations/\d+/threads}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/threads.json"))
+
+      threads = Cubscout::Conversation.new(id: 123).threads
+
+      expect(threads.size).to eq 3
+      expect(threads.first.class).to eq Cubscout::Object
+    end
+  end
+
+  describe "#create_note" do
+    it "creates a text note on a conversation" do
+      stub_request(:post, %r{https://api.helpscout.net/v2/conversations/\d+/notes}).
+        to_return(status: 201)
+
+      expect {
+        Cubscout::Conversation.new(id: 123).create_note(text: "new note")
+      }.not_to raise_exception
+    end
+  end
+
+  describe "#assignee" do
+    it "returns the user assigned to the conversation" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/users/\d+}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/user.json"))
+
+      user = Cubscout::Conversation.new(id: 123, assignee: {id: 55667}).assignee
+
+      expect(user.class).to eq Cubscout::User
     end
   end
 end

--- a/spec/cubscout/user_spec.rb
+++ b/spec/cubscout/user_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe Cubscout::User do
+  describe ".all" do
+    it "gets all users" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/users\?page=*}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/users.json"))
+
+      users = Cubscout::User.all
+
+      expect(users.size).to eq 6
+      expect(users.first.class).to eq Cubscout::User
+    end
+
+    it "gets one page of users" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/users\?page=1}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/users.json"))
+
+      users = Cubscout::User.all(page: 1)
+
+      expect(users.size).to eq 3
+    end
+
+    it "gets a filtered list of users" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/users\?mailbox=121212&page=1}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/users.json"))
+
+      users = Cubscout::User.all(page: 1, mailbox: 121212)
+
+      expect(users.size).to eq 3
+    end
+  end
+
+  describe ".find" do
+    it "gets one user" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/users/\d+}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/user.json"))
+
+      user = Cubscout::User.find(123)
+
+      expect(user.class).to eq Cubscout::User
+    end
+
+    it "attributes are readable as both camel case and snake case" do
+      stub_request(:get, %r{https://api.helpscout.net/v2/users/\d+}).
+        to_return(status: 200, body: File.read("#{__dir__}/../support/user.json"))
+
+      user = Cubscout::User.find(123)
+
+      expect(user.firstName).to eq "Tim"
+      expect(user.first_name).to eq "Tim"
+    end
+  end
+end

--- a/spec/support/conversation.json
+++ b/spec/support/conversation.json
@@ -1,0 +1,45 @@
+{
+  "id": 123123123,
+  "number": 12121,
+  "threads": 1,
+  "type": "email",
+  "folderId": 321321321,
+  "status": "active",
+  "state": "published",
+  "subject": "The email subject",
+  "preview": "I'm a customer and I have a problem",
+  "mailboxId": 121212,
+  "createdBy": {
+    "id": 999888,
+    "type": "customer",
+    "first": "Jules",
+    "last": "Verne",
+    "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+    "email": "jules.verne@aroundtheworld.com"
+  },
+  "createdAt": "2019-04-22T09:04:29Z",
+  "closedBy": 0,
+  "userUpdatedAt": "2019-04-22T09:04:29Z",
+  "customerWaitingSince": {
+    "time": "2019-04-22T09:04:29Z",
+    "friendly": "27 min ago"
+  },
+  "source": {
+    "type": "email",
+    "via": "customer"
+  },
+  "tags": [],
+  "cc": [],
+  "bcc": [],
+  "primaryCustomer": {"id": 999888},
+  "customFields": [],
+  "_links": {
+    "closedBy": {"href": "https://api.helpscout.net/v2/users/0"},
+    "createdByCustomer": {"href": "https://api.helpscout.net/v2/customers/999888"},
+    "mailbox": {"href": "https://api.helpscout.net/v2/mailboxes/121212"},
+    "primaryCustomer": {"href": "https://api.helpscout.net/v2/customers/999888"},
+    "self": {"href": "https://api.helpscout.net/v2/conversations/123123123"},
+    "threads": {"href": "https://api.helpscout.net/v2/conversations/123123123/threads/"},
+    "web": {"href": "https://secure.helpscout.net/conversation/123123123/59596"}
+  }
+}

--- a/spec/support/threads.json
+++ b/spec/support/threads.json
@@ -1,0 +1,119 @@
+{
+  "_embedded": {
+    "threads": [
+      {
+        "id": 44455666777,
+        "type": "note",
+        "status": "active",
+        "state": "published",
+        "action":{"type": "default"},
+        "body": "Email body<br />can contain html<br /><a href=\"https://foo.bar\">foobar</a>",
+        "source":{"type": "web", "via": "user"},
+        "customer":
+         {
+          "id": 999888,
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "createdBy":{
+          "id":777666,
+          "type": "user",
+          "first": "Rob",
+          "last": "Employee",
+          "email": "rob@employee.com"
+        },
+        "assignedTo":{"id":998877, "type": "team", "first": "Urgent matters", "last": "", "email": ""},
+        "savedReplyId": 0,
+        "to":[],
+        "cc":[],
+        "bcc":[],
+        "createdAt": "2019-04-19T08:03:19Z",
+        "_embedded":{"attachments":[]},
+        "_links": {
+          "assignedTo":{"href": "https://api.helpscout.net/v2/users/998877"},
+          "createdByUser":{"href": "https://api.helpscout.net/v2/users/777666"},
+          "customer":{"href": "https://api.helpscout.net/v2/customers/999888"}
+        }
+      }, {
+        "id": 44455666732,
+        "type": "customer",
+        "status": "active",
+        "state": "published",
+        "action":{"type": "default"},
+        "body": "another reply",
+        "source":{"type": "email", "via": "customer"},
+        "customer": {
+          "id": 999888,
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "createdBy": {
+          "id": 999888,
+          "type": "customer",
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "assignedTo":{"id":1, "first": "Help", "last": "Scout", "email": "none@nowhere.com"},
+        "savedReplyId": 0,
+        "to":[],
+        "cc":[],
+        "bcc":[],
+        "createdAt": "2019-04-19T07:58:17Z",
+        "_embedded":{"attachments":[]},
+        "_links": {
+          "assignedTo":{"href": "https://api.helpscout.net/v2/users/1"},
+          "createdByCustomer":{"href": "https://api.helpscout.net/v2/customers/999888"},
+          "customer":{"href": "https://api.helpscout.net/v2/customers/999888"}
+        }
+      }, {
+        "id": 44455666712,
+        "type": "customer",
+        "status": "active",
+        "state": "published",
+        "action":{"type": "default"},
+        "body": "I have a problem",
+        "source":{"type": "email", "via": "customer"},
+        "customer": {
+          "id": 999888,
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "createdBy": {
+          "id": 999888,
+          "type": "customer",
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "assignedTo":{"id":1, "first": "Help", "last": "Scout", "email": "none@nowhere.com"},
+        "savedReplyId": 0,
+        "to":[],
+        "cc":[],
+        "bcc":[],
+        "createdAt": "2019-04-18T13:15:03Z",
+        "_embedded":{"attachments":[]},
+        "_links": {
+          "assignedTo":{"href": "https://api.helpscout.net/v2/users/1"},
+          "createdByCustomer":{"href": "https://api.helpscout.net/v2/customers/999888"},
+          "customer":{"href": "https://api.helpscout.net/v2/customers/999888"}
+        }
+      }
+    ]
+  },
+  "_links": {
+    "first":{"href": "https://api.helpscout.net/v2/conversations/123123123/threads/?page=1"},
+     "last":{"href": "https://api.helpscout.net/v2/conversations/123123123/threads/?page=1"},
+     "page":{"href": "https://api.helpscout.net/v2/conversations/123123123/threads/"},
+     "self":{"href": "https://api.helpscout.net/v2/conversations/123123123/threads/"}
+   },
+   "page":{"size":50, "totalElements":8, "totalPages":1, "number":1}
+}

--- a/spec/support/user.json
+++ b/spec/support/user.json
@@ -1,0 +1,14 @@
+{
+  "id": 55667,
+  "firstName": "Tim",
+  "lastName": "Owner",
+  "email": "tim@owner.com",
+  "role": "owner",
+  "timezone": "Europe/Paris",
+  "photoUrl": "https://random.imageurl.com/tim.jpg",
+  "createdAt": "2019-01-22T08:47:26Z",
+  "updatedAt": "2019-04-19T06:19:47Z",
+  "type": "user",
+  "_links": {"self": {"href": "https://api.helpscout.net/v2/users/55667"}}
+}
+

--- a/spec/support/users.json
+++ b/spec/support/users.json
@@ -1,0 +1,49 @@
+{
+  "_embedded": {
+    "users": [
+      {
+        "id": 55667,
+        "firstName": "Tim",
+        "lastName": "Owner",
+        "email": "tim@owner.com",
+        "role": "owner",
+        "timezone": "Europe/Paris",
+        "photoUrl": "https://random.imageurl.com/tim.jpg",
+        "createdAt": "2019-01-22T08:47:26Z",
+        "updatedAt": "2019-04-19T06:19:47Z",
+        "type": "user",
+        "_links": {"self": {"href": "https://api.helpscout.net/v2/users/55667"}}
+      }, {
+        "id": 334455,
+        "firstName": "Hanna",
+        "lastName": "Admin",
+        "email": "hanna@admin.com",
+        "role": "admin",
+        "timezone": "UTC",
+        "createdAt": "2014-12-22T08:48:38Z",
+        "updatedAt": "2019-04-22T09:13:54Z",
+        "type": "user",
+        "_links": {"self": {"href": "https://api.helpscout.net/v2/users/334455"}}
+      }, {
+        "id": 777666,
+        "firstName": "Rob",
+        "lastName": "Employee",
+        "email": "rob@employee.com",
+        "role": "user",
+        "timezone": "Europe/Berlin",
+        "photoUrl": "https://random.imageurl.com/rob.jpg",
+        "createdAt": "2019-01-11T09:20:26Z",
+        "updatedAt": "2019-04-22T06:32:03Z",
+        "type": "user",
+        "_links": {"self": {"href": "https://api.helpscout.net/v2/users/777666"}}}
+    ]
+  },
+  "_links": {
+    "first": {"href": "https://api.helpscout.net/v2/users?page=1"},
+    "last": {"href": "https://api.helpscout.net/v2/users?page=2"},
+    "next": {"href": "https://api.helpscout.net/v2/users?page=2"},
+    "page": {"href": "https://api.helpscout.net/v2/users?page=1"},
+    "self": {"href": "https://api.helpscout.net/v2/users?page=1"}
+  },
+ "page": {"size": 50, "totalElements": 81, "totalPages": 2, "number": 1}
+}


### PR DESCRIPTION
# About

- specs: all endpoints currently implemented are tested using webmock (so that contributors don't need to rely on a helpscout account)
- change DSL `path 'the_path'` becomes `endpoint 'the_path'` which I find less cryptic