### PR TITLE
Fix: get_token url broken

### DIFF
--- a/lib/cubscout/config.rb
+++ b/lib/cubscout/config.rb
@@ -54,7 +54,7 @@ module Cubscout
             TEXT
           end
 
-          OAuth2::Client.new(@client_id, @client_secret, site: api_prefix, token_url: '/oauth2/token')
+          OAuth2::Client.new(@client_id, @client_secret, site: URI.join(api_prefix, '/').to_s, token_url: "#{URI::parse(api_prefix).path}/oauth2/token")
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/GetSilverfin/cubscout/issues/16

## Description

It looks like Helpscout made a change on their side. So far, we could get a token from

https://api.helpscout.net/oauth2/token

but now it needs to be

https://api.helpscout.net/v2/oauth2/token

We thought we were doing requests to this url all this time, but apparently not.

Let me take you down the path of what happens behind the scenes.

Oauth2 gem uses Faraday in the back:

`OAuth2::Strategy::ClientCredentials#get_token` calls `OAuth2::Client#get_token`: https://github.com/oauth-xx/oauth2/blob/1-4-stable/lib/oauth2/strategy/client_credentials.rb#L20
who itself calls `Faraday::Connection#build_url`: https://github.com/oauth-xx/oauth2/blob/1-4-stable/lib/oauth2/client.rb#L79
who itself calls `Faraday::Connection#build_exclusive_url`: https://github.com/lostisland/faraday/blob/v0.15.4/lib/faraday/connection.rb#L354

Reading this method, we see that it cares about `base` having a path: https://github.com/lostisland/faraday/blob/v0.15.4/lib/faraday/connection.rb#L411-L415

However this line is not behaving as expected https://github.com/lostisland/faraday/blob/v0.15.4/lib/faraday/connection.rb#L416:

```ruby
uri = url ? base + url : base
```

here is an example:

```ruby
[1 pry(main)> base
=> #<URI::HTTPS https://api.helpscout.net/v2/>
[2] pry(main)> url
=> "/oauth2/token"
[3] pry(main)> base + url
=> #<URI::HTTPS https://api.helpscout.net/oauth2/token>
```

As we can see the path of `base` ('/v2/') has been striped. It's unexpected (to me)
that ruby's URI::HTTPS `+` method do this, I would expect it to append to the
existing url instead of replacing the path. but here we are and that's not gonna
change.

Ideally it should be fixed in Faraday. Until it is, this code change is a workaround:
- explicitly strip path in `:site` param
- prepend any path from `api_prefix` to the `:token_url`