### PR TITLE
Fis: travis is failing for ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-before_install: gem update bundler
+before_install: gem install bundler -v '< 2'
 rvm:
  - 2.6
  - 2.5


### PR DESCRIPTION
# About

Try to downgrade bundler to make it work for all ruby versions