### PR TITLE
`Scopes.all` returns a `List` object instead of an array of items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+### Unreleased
+
+**Breaking changes**
+
+- `Cubscout::Scopes.all` method returns a `Cubscout::List` object instead of an array of items [#23](https://github.com/GetSilverfin/cubscout/pull/23)
+
+**Dependencies**
+
+- Bump rack from 2.0.7 to 2.0.8 [#21](https://github.com/GetSilverfin/cubscout/pull/21)
+- Update rake requirement from ~> 10.0 to ~> 13.0 [#22](https://github.com/GetSilverfin/cubscout/pull/22)
+
+### 0.1.1 - 2019-11-14
+
+**Fixes**
+
+- use new Auth endpoint after deprecation of old one by helpscout [#16](https://github.com/GetSilverfin/cubscout/issues/16)
+
+### 0.1.0 - 2019-03-21
+
+BROKEN: DO NOT USE (Auth endpoint deprecated by Helpscout)

--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ List of conversations:
 conversations = Cubscout::Conversation.all
 
 # conversations with filters
-conversations = Cubscout::Conversation.all(page: 1, status: 'active')
+conversations = Cubscout::Conversation.all(tag: 'red,blue', status: 'active')
 
-# Cubscout::Conversation.all returns an array of Cubscout::Conversation objects, from
-# which attributes can be read
+# Cubscout::Conversation.all returns a Cubscout::List object. You can iterate
+# over it's Cubscout::Conversation items like this:
 conversations.each { |conversation| puts conversation.mailbox_id }
+
+# or you can also get some metadata information. For example if you only care
+# about the number of items, you can query the first page only and find out how
+# many elements exist in total:
+Cubscout::Conversation.all(page: 1, tag: 'red,blue', status: 'active').total_size
 ```
 
 Check Helpscout's API documentation for [all supported filters](https://developer.helpscout.com/mailbox-api/endpoints/conversations/list/#url-parameters) and [attributes returned](https://developer.helpscout.com/mailbox-api/endpoints/conversations/list/#response).
@@ -129,9 +134,14 @@ users = Cubscout::User.all
 # users with filters
 users = Cubscout::User.all(mailbox: 12345)
 
-# Cubscout::User.all returns an array of Cubscout::User objects, from
-# which attributes can be read.
+# Cubscout::User.all returns a Cubscout::List object. You can iterate over
+# it's Cubscout::User items like this:
 users.each { |user| puts user.first_name }
+
+# or you can also get some metadata information. For example if you only care
+# about the number of items, you can query the first page only and find out how
+# many elements exist in total:
+Cubscout::User.all(page: 1, mailbox: 12345).total_size
 ```
 
 Check Helpscout's API documentation for [all supported filters](https://developer.helpscout.com/mailbox-api/endpoints/users/list/#url-parameters) and [attributes returned](https://developer.helpscout.com/mailbox-api/endpoints/users/list/#response).

--- a/lib/cubscout/list.rb
+++ b/lib/cubscout/list.rb
@@ -18,7 +18,7 @@ module Cubscout
       raw_payload.dig("page", "number")
     end
 
-    # number of items in the current page (number of +items+)
+    # number of items in the current page. Should be the same as number of +items+, but sometimes it's not (assumption: it's a bug in helpscout)
     def page_size
       raw_payload.dig("page", "size")
     end
@@ -29,13 +29,18 @@ module Cubscout
     end
 
     # total number of items available
-    def size
+    def total_size
       raw_payload.dig("page", "totalElements")
     end
 
     # array of objects Object retrieved from the API's collection endpoint.
     def items
       Array(raw_payload.dig("_embedded", collection_name)).map { |item| object_class.new(item) }
+    end
+
+    # number of +items+
+    def size
+      items.size
     end
 
     def each(&block)

--- a/spec/support/conversations.json
+++ b/spec/support/conversations.json
@@ -83,8 +83,8 @@
   },
   "page": {
     "number": 1,
-    "size": 50,
+    "size": 2,
     "totalPages": 3,
-    "totalElements": 132
+    "totalElements": 6
   }
 }

--- a/spec/support/users.json
+++ b/spec/support/users.json
@@ -45,5 +45,5 @@
     "page": {"href": "https://api.helpscout.net/v2/users?page=1"},
     "self": {"href": "https://api.helpscout.net/v2/users?page=1"}
   },
- "page": {"size": 50, "totalElements": 81, "totalPages": 2, "number": 1}
+ "page": {"size": 3, "totalElements": 6, "totalPages": 2, "number": 1}
 }


### PR DESCRIPTION
Some breaking changes:

**1. `Cubscout::Scopes.all` returns a `Cubscout::List`**

By returning an array of items, we were losing the ability to query the metadata:
page number, total (non-paginated) number of elements found by the query, total
number of pages. We can now query those as part of the returned `Cubscout::List`
object.

By returning a `Cubscout::List` object, we can still iterate over it's items as
the class includes `Enumerable` and was already meant to work this way.

This promotes `Cubscout::List` as a public API class now. So it will be
harder to change it's API.

**2. Cubscout::List method name changes**

`Cubscout::List#size` becomes `Cubscout::List#total_size`: `size` should reflect
the number of elements that can be iterated over, in this case it corresponds to
`Cubscout::List#page_size` (which is now aliased to `:size`).
`Cubscout::List#total_size` is the total amount (non-paginated) of items that
correspond to the query.

This is a breaking change, but `Cubscout::List` was private API so far.