### PR TITLE
On association method calls, do not make a request to Helpscout by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Breaking changes**
 
+- On association method calls, do not make a request to Helpscout by default [#24](https://github.com/GetSilverfin/cubscout/pull/24)
 - `Cubscout::Scopes.all` method returns a `Cubscout::List` object instead of an array of items [#23](https://github.com/GetSilverfin/cubscout/pull/23)
 
 **Dependencies**

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ conversation = Cubscout::Conversation.find(12345)
 # which attributes can be read. attributes can be read as snake case or camel case.
 puts conversation.mailbox_id
 puts conversation.mailboxId
+
+# By default, the threads are not embedded in the conversations payload. They can
+# optionally be returned with the `embed` option:
+Cubscout::Conversation.find(12345, embed: "threads")
 ```
 
 Check Helpscout's API documentation for all [attributes returned](https://developer.helpscout.com/mailbox-api/endpoints/conversations/get/#response)
@@ -96,11 +100,23 @@ In Helpscout's lingo, threads are all the items following a conversation: notes,
 Get the threads for a conversation:
 
 ```ruby
-# by conversation id:
+# by conversation id, will make a request to Helpscout:
 threads = Cubscout::Conversation.threads(conversation_id)
 
-# from a conversation object:
-also_threads = Cubscout::Conversation.find(id).threads
+# from a conversation object, either by embedding threads on conversation request:
+also_threads = Cubscout::Conversation.find(id, embed: 'threads').threads
+# or making the threads request with explicit `fetch` option, will make a request
+# to Helpscout:
+another_way_to_get_threads = Cubscout::Conversation.find(id).threads(fetch: true)
+```
+
+Threads can also be embedded to the List Conversations response payload:
+
+```ruby
+# By default, the threads are not embedded in the conversations payload. They can
+# optionally be returned with the `embed` option:
+conversations = Cubscout::Conversation.all(page: 1, tag: 'red,blue', embed: 'threads')
+threads = conversations.first.threads
 ```
 
 Check Helpscout's API documentation for all [attributes returned](https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/list/#response)
@@ -163,7 +179,14 @@ Check Helpscout's API documentation for all [attributes returned](https://develo
 Get a conversation's assigned user:
 
 ```ruby
+# With limited attributes returned in conversation payload. Small gotcha here:
+# - "first" attributes is renamed to "firstName"
+# - "last" attributes is renamed to "lastName"
+# to keep consistency with the attribute names returned from the /users endpoint
 user = Cubscout::Conversation.find(conversation_id).assignee
+
+# All attributes, will make a request to Helpscout:
+user = Cubscout::Conversation.find(conversation_id).assignee(fetch: true)
 ```
 
 ## Contributing

--- a/lib/cubscout/scopes.rb
+++ b/lib/cubscout/scopes.rb
@@ -61,10 +61,11 @@ module Cubscout
 
       # used with an instance endpoint, get one instance of an Object
       # @param id [Integer] ID of the object to get
+      # @param options [Hash] Optional query params described in Helspcout API documentation
       # @return [Object] Returns an instance of the class where the method is called.
       #   Example: +Foo.find(123) # => returns an instance of Foo+
-      def find(id)
-        self.new(Cubscout.connection.get("#{path}/#{id}").body)
+      def find(id, options = {})
+        self.new(Cubscout.connection.get("#{path}/#{id}", options).body)
       end
     end
 

--- a/spec/support/conversation.json
+++ b/spec/support/conversation.json
@@ -33,6 +33,7 @@
   "bcc": [],
   "primaryCustomer": {"id": 999888},
   "customFields": [],
+  "_embedded": {"threads": []},
   "_links": {
     "closedBy": {"href": "https://api.helpscout.net/v2/users/0"},
     "createdByCustomer": {"href": "https://api.helpscout.net/v2/customers/999888"},

--- a/spec/support/conversation_with_threads.json
+++ b/spec/support/conversation_with_threads.json
@@ -1,0 +1,155 @@
+{
+  "id": 123123123,
+  "number": 12121,
+  "threads": 1,
+  "type": "email",
+  "folderId": 321321321,
+  "status": "active",
+  "state": "published",
+  "subject": "The email subject",
+  "preview": "I'm a customer and I have a problem",
+  "mailboxId": 121212,
+  "createdBy": {
+    "id": 999888,
+    "type": "customer",
+    "first": "Jules",
+    "last": "Verne",
+    "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+    "email": "jules.verne@aroundtheworld.com"
+  },
+  "createdAt": "2019-04-22T09:04:29Z",
+  "closedBy": 0,
+  "userUpdatedAt": "2019-04-22T09:04:29Z",
+  "customerWaitingSince": {
+    "time": "2019-04-22T09:04:29Z",
+    "friendly": "27 min ago"
+  },
+  "source": {
+    "type": "email",
+    "via": "customer"
+  },
+  "tags": [],
+  "cc": [],
+  "bcc": [],
+  "primaryCustomer": {"id": 999888},
+  "customFields": [],
+  "_embedded": {
+    "threads": [
+      {
+        "id": 44455666777,
+        "type": "note",
+        "status": "active",
+        "state": "published",
+        "action":{"type": "default"},
+        "body": "Email body<br />can contain html<br /><a href=\"https://foo.bar\">foobar</a>",
+        "source":{"type": "web", "via": "user"},
+        "customer":
+         {
+          "id": 999888,
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "createdBy":{
+          "id":777666,
+          "type": "user",
+          "first": "Rob",
+          "last": "Employee",
+          "email": "rob@employee.com"
+        },
+        "assignedTo":{"id":998877, "type": "team", "first": "Urgent matters", "last": "", "email": ""},
+        "savedReplyId": 0,
+        "to":[],
+        "cc":[],
+        "bcc":[],
+        "createdAt": "2019-04-19T08:03:19Z",
+        "_embedded":{"attachments":[]},
+        "_links": {
+          "assignedTo":{"href": "https://api.helpscout.net/v2/users/998877"},
+          "createdByUser":{"href": "https://api.helpscout.net/v2/users/777666"},
+          "customer":{"href": "https://api.helpscout.net/v2/customers/999888"}
+        }
+      }, {
+        "id": 44455666732,
+        "type": "customer",
+        "status": "active",
+        "state": "published",
+        "action":{"type": "default"},
+        "body": "another reply",
+        "source":{"type": "email", "via": "customer"},
+        "customer": {
+          "id": 999888,
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "createdBy": {
+          "id": 999888,
+          "type": "customer",
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "assignedTo":{"id":1, "first": "Help", "last": "Scout", "email": "none@nowhere.com"},
+        "savedReplyId": 0,
+        "to":[],
+        "cc":[],
+        "bcc":[],
+        "createdAt": "2019-04-19T07:58:17Z",
+        "_embedded":{"attachments":[]},
+        "_links": {
+          "assignedTo":{"href": "https://api.helpscout.net/v2/users/1"},
+          "createdByCustomer":{"href": "https://api.helpscout.net/v2/customers/999888"},
+          "customer":{"href": "https://api.helpscout.net/v2/customers/999888"}
+        }
+      }, {
+        "id": 44455666712,
+        "type": "customer",
+        "status": "active",
+        "state": "published",
+        "action":{"type": "default"},
+        "body": "I have a problem",
+        "source":{"type": "email", "via": "customer"},
+        "customer": {
+          "id": 999888,
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "createdBy": {
+          "id": 999888,
+          "type": "customer",
+          "first": "Jules",
+          "last": "Verne",
+          "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/customer-avatar/05.png",
+          "email": "jules.verne@aroundtheworld.com"
+        },
+        "assignedTo":{"id":1, "first": "Help", "last": "Scout", "email": "none@nowhere.com"},
+        "savedReplyId": 0,
+        "to":[],
+        "cc":[],
+        "bcc":[],
+        "createdAt": "2019-04-18T13:15:03Z",
+        "_embedded":{"attachments":[]},
+        "_links": {
+          "assignedTo":{"href": "https://api.helpscout.net/v2/users/1"},
+          "createdByCustomer":{"href": "https://api.helpscout.net/v2/customers/999888"},
+          "customer":{"href": "https://api.helpscout.net/v2/customers/999888"}
+        }
+      }
+    ]
+  },
+  "_links": {
+    "closedBy": {"href": "https://api.helpscout.net/v2/users/0"},
+    "createdByCustomer": {"href": "https://api.helpscout.net/v2/customers/999888"},
+    "mailbox": {"href": "https://api.helpscout.net/v2/mailboxes/121212"},
+    "primaryCustomer": {"href": "https://api.helpscout.net/v2/customers/999888"},
+    "self": {"href": "https://api.helpscout.net/v2/conversations/123123123"},
+    "threads": {"href": "https://api.helpscout.net/v2/conversations/123123123/threads/"},
+    "web": {"href": "https://secure.helpscout.net/conversation/123123123/59596"}
+  }
+}

--- a/spec/support/conversations.json
+++ b/spec/support/conversations.json
@@ -30,6 +30,7 @@
         "bcc": [],
         "primaryCustomer": {"id": 999888},
         "customFields": [],
+        "_embedded": {"threads": []},
         "_links": {
           "closedBy": {"href": "https://api.helpscout.net/v2/users/0"},
           "createdByCustomer": {"href": "https://api.helpscout.net/v2/customers/999888"},
@@ -69,6 +70,7 @@
         "bcc": [],
         "primaryCustomer": {"id": 3333222},
         "customFields": [],
+        "_embedded": {"threads": []},
         "_links": {
           "closedBy": {"href": "https://api.helpscout.net/v2/users/0"},
           "createdByCustomer": {"href": "https://api.helpscout.net/v2/customers/3333222"},


### PR DESCRIPTION
Some method calls trigger a request to helpscout. That could be surprizing,
especially if triggered within a loop. Try to make calls as explicit as possible
by passing a `fetch` option on associations calls.

Breaking changes:

- `Conversation#assignee` does not make a request to Helpscout by default. It
  uses the `assignee` payload provided in the conversation payload. An optional
  `fetch` parameter can be passed to make a request to Helpscout
- `Conversation#threads` does not make a request to Helpscout by default. It uses
  the threads payload in the conversation payload. By default, threads are not
  embedded, so document in README how to pass the `embed: "threads"` option.

Non-breaking change:

- Scopes.find allows for an optional `options` hash. For example, this allows to
  embed threads in the Get Conversation endpoint.