### PR TITLE
Use named `ThreadItem` and `Error` instead of generic object & error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Breaking changes**
 
+- Use named `ThreadItem` and `Error` instead of generic object & error [#25](https://github.com/GetSilverfin/cubscout/pull/25)
 - On association method calls, do not make a request to Helpscout by default [#24](https://github.com/GetSilverfin/cubscout/pull/24)
 - `Cubscout::Scopes.all` method returns a `Cubscout::List` object instead of an array of items [#23](https://github.com/GetSilverfin/cubscout/pull/23)
 

--- a/lib/cubscout.rb
+++ b/lib/cubscout.rb
@@ -10,6 +10,7 @@ require "cubscout/list"
 require "cubscout/object"
 require "cubscout/conversation"
 require "cubscout/user"
+require "cubscout/thread_item"
 
 module Cubscout
   class Error < StandardError; end

--- a/lib/cubscout/conversation.rb
+++ b/lib/cubscout/conversation.rb
@@ -9,7 +9,7 @@ module Cubscout
       # @param id [Integer] the conversation ID
       # @return [Array<Object>] thread items
       def threads(id)
-        Cubscout.connection.get("#{path}/#{id}/threads").body.dig("_embedded", "threads").map { |item| Object.new(item) }
+        Cubscout.connection.get("#{path}/#{id}/threads").body.dig("_embedded", "threads").map { |item| ThreadItem.new(item) }
       end
 
       # Create a note to a conversation.
@@ -77,7 +77,7 @@ module Cubscout
       if fetch
         Conversation.threads(self.id)
       else
-        self.attributes.dig("_embedded", "threads").map { |item| Object.new(item) }
+        self.attributes.dig("_embedded", "threads").map { |item| ThreadItem.new(item) }
       end
     end
 

--- a/lib/cubscout/scopes.rb
+++ b/lib/cubscout/scopes.rb
@@ -32,7 +32,7 @@ module Cubscout
       #   foos.total_size # 335 with this filter
       #   foos.each { |foo_element| puts "ID is #{foo_element.id}" }
       def all(options = {})
-        raise "No path given" unless path
+        raise Error, "`#{self}.all` method is not available" unless path
 
         raw_first_or_requested_page = Cubscout.connection.get(path, page: options[:page] || 1, **options).body
         first_or_requested_page = List.new(raw_first_or_requested_page, path, self)
@@ -65,6 +65,8 @@ module Cubscout
       # @return [Object] Returns an instance of the class where the method is called.
       #   Example: +Foo.find(123) # => returns an instance of Foo+
       def find(id, options = {})
+        raise Error, "`#{self}.find` method is not available" unless path
+
         self.new(Cubscout.connection.get("#{path}/#{id}", options).body)
       end
     end

--- a/lib/cubscout/thread_item.rb
+++ b/lib/cubscout/thread_item.rb
@@ -1,0 +1,4 @@
+module Cubscout
+  class ThreadItem < Object
+  end
+end

--- a/spec/cubscout/conversation_spec.rb
+++ b/spec/cubscout/conversation_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Cubscout::Conversation do
       threads = Cubscout::Conversation.threads(123)
 
       expect(threads.size).to eq 3
-      expect(threads.first.class).to eq Cubscout::Object
+      expect(threads.first.class).to eq Cubscout::ThreadItem
     end
   end
 
@@ -173,7 +173,7 @@ RSpec.describe Cubscout::Conversation do
       threads = Cubscout::Conversation.new(id: 123).threads(fetch: true)
 
       expect(threads.size).to eq 3
-      expect(threads.first.class).to eq Cubscout::Object
+      expect(threads.first.class).to eq Cubscout::ThreadItem
     end
 
     it "gets the threads of a conversation by embedding them in conversation" do
@@ -183,7 +183,7 @@ RSpec.describe Cubscout::Conversation do
       threads = Cubscout::Conversation.find(123, embed: "threads").threads
 
       expect(threads.size).to eq 3
-      expect(threads.first.class).to eq Cubscout::Object
+      expect(threads.first.class).to eq Cubscout::ThreadItem
     end
   end
 


### PR DESCRIPTION
New `Cubscout::ThreadItem` model inheriting from `Cubscout::Object`. This allows
for future extension of the thread domain.

Raise a `Cubscout::Error` on unavailable methods. Ideally it should be it's own
error class inheriting from `Error`, but the API is not quite clear yet.